### PR TITLE
Add test for product detail Fixes #1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 aiohttp==3.4.4
+aioresponses==0.4.2

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,6 @@
 import unittest
-
+import asyncio
+from aioresponses import aioresponses
 from pygramed import PyGramedia
 
 
@@ -13,6 +14,30 @@ class PyGramediaTest(unittest.TestCase):
 
     def test_repr_category(self):
         self.assertEqual(str(self.pg.category), '<CategoryAPI: https://www.gramedia.com/api/categories/>')
+
+    @aioresponses()
+    def test_product_retrieve_detail(self, mocked=None):
+        expected = {
+            "name": "Perpajakan Bendahara Desa",
+            "authors": [
+                {
+                    "title": "M.bahrun Nawawi",
+                    "href": "https://www.gramedia.com/api/authors/author-mbahrun-nawawi/"
+                }
+            ],
+            "formats": [
+                {
+                    "name": "Perpajakan Bendahara Desa",
+                    "title": "Soft Cover",
+                }
+            ],
+            "thumbnail": "https://cdn.gramedia.com/uploads/items/9789790625433_perpajakan-bendahara-desa.jpg",
+            "href": "https://www.gramedia.com/api/products/perpajakan-bendahara-desa/",
+        }
+        loop = asyncio.get_event_loop()
+        mocked.get('https://www.gramedia.com/api/products/?per_page=1', payload=dict(**expected))
+        resp = loop.run_until_complete(self.pg.product.retrieve(limit=1))
+        self.assertIn('perpajakan-bendahara-desa', resp['href'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi,

Here is a test for basic functionality. This bumps [coverage](https://github.com/nedbat/coveragepy/tree/v4.5.x) from 53% to 86% :smile: 

I would suggest you to create helpers for PyGramedia responses which could return objects instead of list of dictionaries, they would be easier to mock :godmode: 