### PR TITLE
Create helpers for PyGramedia response Fixes #3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,2 @@
 [run]
-include = pygramed/__init__.py
+include = pygramed/*

--- a/pygramed/__init__.py
+++ b/pygramed/__init__.py
@@ -2,7 +2,8 @@ import asyncio
 import random
 import urllib
 from typing import List, Optional, Union
-
+import types
+from pygramed.models import Product
 from aiohttp import ClientSession
 
 # Reference: https://github.com/tamimibrahim17/List-of-user-agents
@@ -53,7 +54,8 @@ class BaseAPI:
         header = {"User:Agent": random.choice(USER_AGENTS)}
         async with ClientSession() as session:
             async with session.get(url=url, headers=header) as response:
-                return await response.json(encoding='utf8')
+                res = await response.json(encoding='utf-8')
+                return [Product.create_from_json(x) for x in res]
 
     async def _post(self, url: str, data: dict):
         header = {"User:Agent": random.choice(USER_AGENTS)}
@@ -72,6 +74,16 @@ class ProductAPI(BaseAPI):
         self.url = f'{self._base_url}/products/'
 
     def retrieve(self,
+                 category: Optional[Union[List[str], str]] = None,
+                 limit: Optional[int] = None) -> List[Product]:
+        return self._retrieve(category, limit, True)
+
+    def retrieve_async(self,
+                       category: Optional[Union[List[str], str]] = None,
+                       limit: Optional[int] = None) -> types.CoroutineType:
+        return self._retrieve(category, limit, False)
+
+    def _retrieve(self,
                  category: Optional[Union[List[str], str]] = None,
                  limit: Optional[int] = None,
                  sync: bool = False):

--- a/pygramed/models.py
+++ b/pygramed/models.py
@@ -1,5 +1,7 @@
 from decimal import Decimal as D
 
+from dateutil.parser import parse
+
 
 class GramediaObject(object):
     def __init__(self, href: str = "", title: str = ""):
@@ -100,12 +102,12 @@ class Format(GramediaObject):
             is_allow_insurance=data.get("isAllowInsurance", False),
             is_extra_packing=data.get("isExtraPacking", False),
             name=data.get("name", None),
-            pre_order_end=data.get("preOrderEnd", None),  # TODO datetime?
-            pre_order_start=data.get("preOrderStart", None),  # TODO datetime?
-            promo_id=data.get("promoId", None),
+            pre_order_end=parse(data.get("preOrderEnd")) if data.get("preOrderEnd") else None,
+            pre_order_start=parse(data.get("preOrderStart")) if data.get("preOrderEnd") else None,
+            promo_id=data.get("promoId", ""),
             promo_percentage=D(str(data.get("promoPercentage"))) if data.get("promoPercentage") else None,
             promo_price=D(str(data.get("promoPrice"))) if data.get("promoPrice") else None,
-            publish_date=data.get("publishDate", None),  # TODO datetime?
+            publish_date=parse(data.get("publishDate")) if data.get("publishDate") else None,
             rel=data.get("rel", None),
             sales_end=data.get("salesEnd", None),
             sales_start=data.get("salesStart", None),

--- a/pygramed/models.py
+++ b/pygramed/models.py
@@ -39,6 +39,14 @@ class Shipping(object):
         )
 
 
+class Image(object):
+    def __init__(self, href: str = ""):
+        self.href = href
+
+    def __str__(self):
+        return self.href
+
+
 class Variant(object):
     def __init__(self, warna_tinta: str = ""):
         self.warna_tinta = warna_tinta
@@ -51,10 +59,10 @@ class Variant(object):
 
 
 class Format(GramediaObject):
-    def __init__(self, base_price: str = "", href: str = "", images: str = "", is_allow_insurance: str = "",
+    def __init__(self, base_price: str = "", href: str = "", images: [Image] = list(), is_allow_insurance: str = "",
                  is_extra_packing: str = "", name: str = "", pre_order_end: str = "", pre_order_start: str = "",
                  promo_id: str = "", promo_percentage: str = "", promo_price: str = "", publish_date: str = "",
-                 rel: str = "", sales_end: str = "", sales_start: str = "", shipping: [Shipping] = list(),
+                 rel: str = "", sales_end: str = "", sales_start: str = "", shipping: Shipping = Shipping(),
                  sku: str = "",
                  stock_level: int = 0, title: str = "", type: str = "", variant: Variant = None, version: str = "",
                  weight: str = ""):
@@ -83,35 +91,32 @@ class Format(GramediaObject):
 
     @classmethod
     def create_from_json(cls, data):
-        shipping_data = [x for x in data.get('shipping', [])]
-        shipping = [Shipping.create_from_json(x) for x in shipping_data]
-
-        variants_data = data.get('variants', {})
-        variants = Variant.create_from_json(variants_data)
+        shipping = Shipping.create_from_json(data.get('shipping', {}))
+        variant = Variant.create_from_json(data.get('variants', {}))
         return cls(
             base_price=D(str(data.get("basePrice"))) if data.get("basePrice") else None,
-            href=data.get("href", ""),
-            images=data.get("images", []),  # TODO
+            href=data.get("href", None),
+            images=[Image(i) for i in data.get("images", [])],
             is_allow_insurance=data.get("isAllowInsurance", False),
             is_extra_packing=data.get("isExtraPacking", False),
-            name=data.get("name", ""),
-            pre_order_end=data.get("preOrderEnd", ""),  # TODO datetime?
-            pre_order_start=data.get("preOrderStart", ""),  # TODO datetime?
-            promo_id=data.get("promoId", ""),
+            name=data.get("name", None),
+            pre_order_end=data.get("preOrderEnd", None),  # TODO datetime?
+            pre_order_start=data.get("preOrderStart", None),  # TODO datetime?
+            promo_id=data.get("promoId", None),
             promo_percentage=D(str(data.get("promoPercentage"))) if data.get("promoPercentage") else None,
             promo_price=D(str(data.get("promoPrice"))) if data.get("promoPrice") else None,
-            publish_date=data.get("publishDate", ""),  # TODO datetime?
-            rel=data.get("rel", ""),
-            sales_end=data.get("salesEnd", ""),
-            sales_start=data.get("salesStart", ""),
+            publish_date=data.get("publishDate", None),  # TODO datetime?
+            rel=data.get("rel", None),
+            sales_end=data.get("salesEnd", None),
+            sales_start=data.get("salesStart", None),
             shipping=shipping,
-            sku=data.get("sku", ""),
+            sku=data.get("sku", None),
             stock_level=int(data.get("stockLevel", 0)),
-            title=data.get("title", ""),
-            type=data.get("type", ""),
-            variant=variants,
-            version=data.get("version", ""),
-            weight=data.get("weight", "")
+            title=data.get("title", None),
+            type=data.get("type", None),
+            variant=variant,
+            version=data.get("version", None),
+            weight=data.get("weight", None)
         )
 
 
@@ -132,12 +137,9 @@ class Product(object):
 
     @classmethod
     def create_from_json(cls, data):
-        authors_data = [x for x in data.get('authors')]
-        authors = [Author.create_from_json(x) for x in authors_data]
-        categories_data = [x for x in data.get('authors')]
-        categories = [Category.create_from_json(x) for x in categories_data]
-        formats_data = [x for x in data.get('authors')]
-        formats = [Format.create_from_json(x) for x in formats_data]
+        authors = [Author.create_from_json(x) for x in data.get('authors', [])]
+        categories = [Category.create_from_json(x) for x in data.get('categories', [])]
+        formats = [Format.create_from_json(x) for x in data.get('formats', [])]
         return cls(
             authors=authors,
             categories=categories,

--- a/pygramed/models.py
+++ b/pygramed/models.py
@@ -1,0 +1,152 @@
+from decimal import Decimal as D
+
+
+class GramediaObject(object):
+    def __init__(self, href: str = "", title: str = ""):
+        self.href = href
+        self.title = title
+
+    @classmethod
+    def create_from_json(cls, data):
+        return cls(
+            href=data.get("href", None),
+            title=data.get("title", None)
+        )
+
+
+class Author(GramediaObject):
+    pass
+
+
+class Category(GramediaObject):
+    pass
+
+
+class Shipping(object):
+    def __init__(self, width: str = "", height: str = "", length: str = "", weight: str = ""):
+        self.width = width
+        self.height = height
+        self.length = length
+        self.weight = weight
+
+    @classmethod
+    def create_from_json(cls, data):
+        return cls(
+            width=data.get("width", None),
+            height=data.get("height", None),
+            length=data.get("length", None),
+            weight=data.get("weight", None)
+        )
+
+
+class Variant(object):
+    def __init__(self, warna_tinta: str = ""):
+        self.warna_tinta = warna_tinta
+
+    @classmethod
+    def create_from_json(cls, data):
+        return cls(
+            warna_tinta=data.get("Warna Tinta", None)
+        )
+
+
+class Format(GramediaObject):
+    def __init__(self, base_price: str = "", href: str = "", images: str = "", is_allow_insurance: str = "",
+                 is_extra_packing: str = "", name: str = "", pre_order_end: str = "", pre_order_start: str = "",
+                 promo_id: str = "", promo_percentage: str = "", promo_price: str = "", publish_date: str = "",
+                 rel: str = "", sales_end: str = "", sales_start: str = "", shipping: [Shipping] = list(),
+                 sku: str = "",
+                 stock_level: int = 0, title: str = "", type: str = "", variant: Variant = None, version: str = "",
+                 weight: str = ""):
+        super(Format, self).__init__(href, title)
+        self.base_pric = base_price
+        self.images = images
+        self.is_allow_insurance = is_allow_insurance
+        self.is_extra_packing = is_extra_packing
+        self.name = name
+        self.pre_order_end = pre_order_end
+        self.pre_order_start = pre_order_start
+        self.promo_id = promo_id
+        self.promo_percentage = promo_percentage
+        self.promo_price = promo_price
+        self.publish_date = publish_date
+        self.rel = rel
+        self.sales_end = sales_end
+        self.sales_start = sales_start
+        self.shipping = shipping
+        self.sku = sku
+        self.stock_level = stock_level
+        self.type = type
+        self.variant = variant
+        self.version = version
+        self.weight = weight
+
+    @classmethod
+    def create_from_json(cls, data):
+        shipping_data = [x for x in data.get('shipping', [])]
+        shipping = [Shipping.create_from_json(x) for x in shipping_data]
+
+        variants_data = data.get('variants', {})
+        variants = Variant.create_from_json(variants_data)
+        return cls(
+            base_price=D(str(data.get("basePrice"))) if data.get("basePrice") else None,
+            href=data.get("href", ""),
+            images=data.get("images", []),  # TODO
+            is_allow_insurance=data.get("isAllowInsurance", False),
+            is_extra_packing=data.get("isExtraPacking", False),
+            name=data.get("name", ""),
+            pre_order_end=data.get("preOrderEnd", ""),  # TODO datetime?
+            pre_order_start=data.get("preOrderStart", ""),  # TODO datetime?
+            promo_id=data.get("promoId", ""),
+            promo_percentage=D(str(data.get("promoPercentage"))) if data.get("promoPercentage") else None,
+            promo_price=D(str(data.get("promoPrice"))) if data.get("promoPrice") else None,
+            publish_date=data.get("publishDate", ""),  # TODO datetime?
+            rel=data.get("rel", ""),
+            sales_end=data.get("salesEnd", ""),
+            sales_start=data.get("salesStart", ""),
+            shipping=shipping,
+            sku=data.get("sku", ""),
+            stock_level=int(data.get("stockLevel", 0)),
+            title=data.get("title", ""),
+            type=data.get("type", ""),
+            variant=variants,
+            version=data.get("version", ""),
+            weight=data.get("weight", "")
+        )
+
+
+class Product(object):
+
+    def __init__(self, authors, categories, formats, href: str = "", is_bestseller: str = "", is_new: str = "",
+                 is_promo: str = "", name: str = "", tags: str = "", thumbnail: str = ""):
+        self.authors = authors
+        self.categories = categories
+        self.formats = formats
+        self.href = href
+        self.is_bestseller = is_bestseller
+        self.is_new = is_new
+        self.is_promo = is_promo
+        self.name = name
+        self.tags = tags
+        self.thumbnail = thumbnail
+
+    @classmethod
+    def create_from_json(cls, data):
+        authors_data = [x for x in data.get('authors')]
+        authors = [Author.create_from_json(x) for x in authors_data]
+        categories_data = [x for x in data.get('authors')]
+        categories = [Category.create_from_json(x) for x in categories_data]
+        formats_data = [x for x in data.get('authors')]
+        formats = [Format.create_from_json(x) for x in formats_data]
+        return cls(
+            authors=authors,
+            categories=categories,
+            formats=formats,
+            href=data.get("href", None),
+            is_bestseller=data.get("isBestseller", None),
+            is_new=data.get("isNew", None),
+            is_promo=data.get("isPromo", None),
+            name=data.get("name", None),
+            tags=data.get("tags", None),
+            thumbnail=data.get("thumbnail", None)
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ aiohttp==3.4.4
 aioresponses==0.4.2
 coverage==4.5.1
 coveralls==1.5.1
+python-dateutil==2.7.3

--- a/tests.py
+++ b/tests.py
@@ -18,7 +18,7 @@ class PyGramediaTest(unittest.TestCase):
         self.assertEqual(str(self.pg.category), '<CategoryAPI: https://www.gramedia.com/api/categories/>')
 
     @aioresponses()
-    def test_product_retrieve_detail(self, mocked=None):
+    def test_product_retrieve_detail_async(self, mocked=None):
         expected = [{
             "name": "Perpajakan Bendahara Desa",
             "authors": [
@@ -42,7 +42,7 @@ class PyGramediaTest(unittest.TestCase):
         self.assertIn('perpajakan-bendahara-desa', resp[0].href)
 
     @aioresponses()
-    def test_product_retrieve_detail_sync(self, mocked=None):
+    def test_product_retrieve_detail(self, mocked=None):
         expected = [{
             "name": "Perpajakan Bendahara Desa",
             "authors": [
@@ -55,6 +55,10 @@ class PyGramediaTest(unittest.TestCase):
                 {
                     "name": "Perpajakan Bendahara Desa",
                     "title": "Soft Cover",
+                    "images": [
+                        "https://cdn.gramedia.com/uploads/images/207998594_STANDARD-BLIVE-NO.jpg",
+                        "https://cdn.gramedia.com/uploads/images/207998594_2_STANDARD-BLIVE-.jpg"
+                    ],
                 }
             ],
             "thumbnail": "https://cdn.gramedia.com/uploads/items/9789790625433_perpajakan-bendahara-desa.jpg",
@@ -63,6 +67,8 @@ class PyGramediaTest(unittest.TestCase):
         mocked.get('https://www.gramedia.com/api/products/?per_page=1', payload=list(expected))
         resp = self.pg.product.retrieve(limit=1)
         self.assertIn('perpajakan-bendahara-desa', resp[0].href)
+        self.assertEqual(str(resp[0].formats[0].images[0]),
+                         "https://cdn.gramedia.com/uploads/images/207998594_STANDARD-BLIVE-NO.jpg")
 
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -38,8 +38,31 @@ class PyGramediaTest(unittest.TestCase):
         }]
         loop = asyncio.get_event_loop()
         mocked.get('https://www.gramedia.com/api/products/?per_page=1', payload=list(expected))
-        resp = loop.run_until_complete(self.pg.product.retrieve(limit=1))
-        self.assertIn('perpajakan-bendahara-desa', resp[0]['href'])
+        resp = loop.run_until_complete(self.pg.product.retrieve_async(limit=1))
+        self.assertIn('perpajakan-bendahara-desa', resp[0].href)
+
+    @aioresponses()
+    def test_product_retrieve_detail_sync(self, mocked=None):
+        expected = [{
+            "name": "Perpajakan Bendahara Desa",
+            "authors": [
+                {
+                    "title": "M.bahrun Nawawi",
+                    "href": "https://www.gramedia.com/api/authors/author-mbahrun-nawawi/"
+                }
+            ],
+            "formats": [
+                {
+                    "name": "Perpajakan Bendahara Desa",
+                    "title": "Soft Cover",
+                }
+            ],
+            "thumbnail": "https://cdn.gramedia.com/uploads/items/9789790625433_perpajakan-bendahara-desa.jpg",
+            "href": "https://www.gramedia.com/api/products/perpajakan-bendahara-desa/",
+        }]
+        mocked.get('https://www.gramedia.com/api/products/?per_page=1', payload=list(expected))
+        resp = self.pg.product.retrieve(limit=1)
+        self.assertIn('perpajakan-bendahara-desa', resp[0].href)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi @Keda87 & Thanks for helping me with open source projects :smile: (I'm more familiar with corporate approach :cry: )

I've created basic version of models that can be initialized from json response. I've separated functions `retrieve` and `retrieve_async` because they have different returning datatypes (I think this is a cleaner solution but it can break backward compatibility.... the serialization breaks it as well :laughing: perhaps separating serialization can be for discussion)

There are few TODOs (I wasn't able to find structure for `Format.images`, datetime is in question..).
Let me know what you think.
Cheers :v: